### PR TITLE
Add Python 3 support

### DIFF
--- a/flask_redis.py
+++ b/flask_redis.py
@@ -1,7 +1,4 @@
 from redis import Redis as RedisClass
-import inspect
-import urlparse
-from werkzeug.utils import import_string
 
 __all__ = ('Redis',)
 


### PR DESCRIPTION
Removed unused imports, including one for urlparse that has been renamed in Python 3
