### PR TITLE
Registered flask_redis as an extension with the Flask app and mocked out the redis client

### DIFF
--- a/flask_redis.py
+++ b/flask_redis.py
@@ -21,6 +21,11 @@ class Redis(object):
         """
         self.app = app
 
+        # Register extension
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        app.extensions['redis'] = self
+
         self.key = lambda suffix: '{0}_{1}'.format(
             self.config_prefix,
             suffix

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ invoke
 pytest
 pytest-cov
 pytest-pep8
+flask
+redis
+mock
+mockredispy

--- a/test_flask_redis.py
+++ b/test_flask_redis.py
@@ -9,6 +9,7 @@ import unittest
 from mock import patch
 from mockredis import mock_redis_client
 
+
 class FlaskRedisTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/test_flask_redis.py
+++ b/test_flask_redis.py
@@ -6,7 +6,8 @@
 import flask
 from flask_redis import Redis
 import unittest
-
+from mock import patch
+from mockredis import mock_redis_client
 
 class FlaskRedisTestCase(unittest.TestCase):
 
@@ -15,13 +16,23 @@ class FlaskRedisTestCase(unittest.TestCase):
         self.redis = Redis()
         self.app = flask.Flask(__name__)
 
-    def test_init_app(self):
+    @patch('redis.Redis.from_url')
+    def test_init_app(self, redis_from_url):
         """ Test the initation of our Redis extension """
+        redis_from_url.return_value = mock_redis_client()
+
         self.redis.init_app(self.app)
         assert self.redis.get('potato') is None
+        assert hasattr(self.app, 'extensions')
+        assert 'redis' in self.app.extensions
+        assert self.redis == self.app.extensions['redis']
 
-    def test_custom_prefix(self):
+    @patch('redis.Redis.from_url')
+    def test_custom_prefix(self, redis_from_url):
         """ Test the use of custom config prefixes """
+
+        redis_from_url.return_value = mock_redis_client()
+
         self.db1_redis = Redis(config_prefix='DB1')
         self.app.config['DB1_URL'] = "redis://localhost:6379"
         self.app.config['DB1_DATABASE'] = 0


### PR DESCRIPTION
@rhyselsmore 

I needed to have the extension registered with the app, so that we can do:

```
current_app.extensions['redis'].get("myrediskey")
```

As recommended by Flask's docs (http://flask.pocoo.org/docs/0.10/api/) look at extensions property of Flask.

Besides this change, I mocked out the redis client so that the unit tests don't connect to Redis. 

The requirements did not have flask or redis, so I added them to the pip's requirements.txt file as well.