### PR TITLE
Add alternative Redis client support with `provider`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+CURRENT (2/2/2015)
+------------------
+
+- Added provider support for swapping between Redis, StrictRedis, and MockRedis
+- Updated tests for py.test
+- API Change: Redis is now FlaskRedis for clearer stack traces.
+- API Change: Removed support for the 'db' argument, use the URL for that.
+
 0.0.6 (4/9/2014)
 ----------------
 

--- a/flask_redis.py
+++ b/flask_redis.py
@@ -1,48 +1,21 @@
-from redis import Redis as RedisClass
+from redis import Redis as _Redis
 
-__all__ = ('Redis',)
+__all__ = ('FlaskRedis',)
 
 
-class Redis(object):
-
-    def __init__(self, app=None, config_prefix=None):
-        """
-        Constructor for non-factory Flask applications
-        """
-
-        self.config_prefix = config_prefix or 'REDIS'
-
+class FlaskRedis(object):
+    def __init__(self, app=None, config_prefix='REDIS', provider=None):
+        self.config_prefix = config_prefix
+        self.redis_client = None
         if app is not None:
-            self.init_app(app)
+            self.init_app(app, provider=provider)
 
-    def init_app(self, app):
-        """
-        Apply the Flask app configuration to a Redis object
-        """
-        self.app = app
+    def init_app(self, app, provider=None):
+        redis_url = app.config.get('{}_URL'.format(self.config_prefix),
+                                   'redis://localhost:6379/0')
+        if provider is None:
+            provider = _Redis
+        self.redis_client = provider.from_url(redis_url)
 
-        self.key = lambda suffix: '{0}_{1}'.format(
-            self.config_prefix,
-            suffix
-        )
-
-        self.app.config.setdefault(self.key('URL'), 'redis://localhost:6379')
-
-        db = self.app.config.get(self.key('DATABASE'))
-
-        self.connection = connection = RedisClass.from_url(
-            self.app.config.get(self.key('URL')),
-            db=db,
-        )
-
-        self._include_connection_methods(connection)
-
-    def _include_connection_methods(self, connection):
-        """
-        Include methods from connection instance to current instance.
-        """
-        for attr in dir(connection):
-            value = getattr(connection, attr)
-            if attr.startswith('_') or not callable(value):
-                continue
-            self.__dict__[attr] = value
+    def __getattr__(self, name):
+        return getattr(self.redis_client, name)

--- a/test_flask_redis.py
+++ b/test_flask_redis.py
@@ -4,43 +4,57 @@
 """Tests for Flask-Redis."""
 
 import flask
-from flask_redis import Redis
-import unittest
+from flask_redis import FlaskRedis
+import pytest
 
 
-class FlaskRedisTestCase(unittest.TestCase):
+@pytest.fixture
+def app():
+    return flask.Flask(__name__)
 
-    def setUp(self):
-        """ Create a sample Flask Application """
-        self.redis = Redis()
-        self.app = flask.Flask(__name__)
 
-    def test_init_app(self):
-        """ Test the initation of our Redis extension """
-        self.redis.init_app(self.app)
-        assert self.redis.get('potato') is None
+class FakeProvider(object):
+    @classmethod
+    def from_url(cls, *args, **kwargs):
+        return cls()
 
-    def test_custom_prefix(self):
-        """ Test the use of custom config prefixes """
-        self.db1_redis = Redis(config_prefix='DB1')
-        self.app.config['DB1_URL'] = "redis://localhost:6379"
-        self.app.config['DB1_DATABASE'] = 0
-        self.db1_redis.init_app(self.app)
 
-        self.db2_redis = Redis(config_prefix='DB2')
-        self.app.config['DB2_URL'] = "redis://localhost:6379"
-        self.app.config['DB2_DATABASE'] = 1
-        self.db2_redis.init_app(self.app)
+def test_constructor(app):
+    '''Test that a constructor with app instance will initialize the
+    connection'''
+    redis = FlaskRedis(app)
+    assert redis.redis_client is not None
+    assert hasattr(redis.redis_client, 'connection_pool')
 
-        self.db3_redis = Redis(config_prefix='DB3')
-        self.app.config['DB3_URL'] = "redis://localhost:6379"
-        self.db3_redis.init_app(self.app)
 
-        self.db4_redis = Redis(config_prefix='DB4')
-        self.app.config['DB4_URL'] = "redis://localhost:6379/5"
-        self.db4_redis.init_app(self.app)
+def test_init_app(app):
+    '''Test that a constructor without app instance will not initialize the
+    connection.
 
-        assert self.db1_redis.get('potato') is None
-        assert self.db2_redis.get('potato') is None
-        assert self.db3_redis.get('potato') is None
-        assert self.db4_redis.get('potato') is None
+    After FlaskRedis.init_app(app) is called, the connection will be
+    initialized.'''
+    redis = FlaskRedis()
+    assert redis.redis_client is None
+    redis.init_app(app)
+    assert redis.redis_client is not None
+    assert hasattr(redis.redis_client, 'connection_pool')
+
+
+def test_custom_prefix(app):
+    '''Test that config prefixes enable distinct connections'''
+    app.config['DBA_URL'] = 'redis://localhost:6379/1'
+    app.config['DBB_URL'] = 'redis://localhost:6379/2'
+    redis_a = FlaskRedis(app, config_prefix='DBA')
+    redis_b = FlaskRedis(app, config_prefix='DBB')
+    assert redis_a.connection_pool.connection_kwargs['db'] == 1
+    assert redis_b.connection_pool.connection_kwargs['db'] == 2
+
+
+def test_custom_provider(app):
+    '''Test that FlaskRedis can be instructed to use a different Redis client,
+    like StrictRedis'''
+    redis = FlaskRedis()
+    assert redis.redis_client is None
+    redis.init_app(app, provider=FakeProvider)
+    assert redis.redis_client is not None
+    assert isinstance(redis.redis_client, FakeProvider)


### PR DESCRIPTION
I wanted to use `mockredis`_ for unit tests in another project. But I found that `flask_redis` did not support the substitution of another Redis client. And because `flask_redis.Redis` copies bound public methods over from `redis.Redis` at runtime, I couldn't patch in a `unittest.Mock` autospec.

So, I've added a new argument for the constructor called `provider`. This argument allows one to use `mockredis` or even `StrictRedis` as desired.

I've renamed the `flask_redis.Redis` class to `flask_redis.FlaskRedis` for clarity in the call stack.

I've removed the bound attribute copying to make it easier to debug. I would have gone with a subclass of `redis.Redis`, but it would have made it impossible to swap in `MockRedis` at runtime without Very Bad Things, like modifying `__bases__`.

I've removed the `db` parameter from the constructor as it duplicates functionality provided in the url and makes the underlying api more difficult.

I've also ported the tests from `unittest` to `py.test` proper.

**This is an API-breaking change.**