### PR TITLE
Add explicit encoding for README.rst in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author='Rhys Elsmore',
     author_email='me@rhys.io',
     description='Redis Extension for Flask Applications',
-    long_description=open('README.rst').read() + '\n\n' +
+    long_description=open('README.rst', encoding='utf-8').read() + '\n\n' +
         open('HISTORY.rst').read(),
     py_modules=['flask_redis'],
     license=open('LICENSE').read(),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import codecs
 
 import os
 import sys
@@ -20,7 +21,7 @@ setup(
     author='Rhys Elsmore',
     author_email='me@rhys.io',
     description='Redis Extension for Flask Applications',
-    long_description=open('README.rst', encoding='utf-8').read() + '\n\n' +
+    long_description=codecs.open('README.rst', encoding='utf-8').read() + '\n\n' +
         open('HISTORY.rst').read(),
     py_modules=['flask_redis'],
     license=open('LICENSE').read(),


### PR DESCRIPTION
Without this the install fails in systems where `sys.getfilesystemencoding()` is `'ascii'`. 

(My name is to blame for this—it contains a special character and it's in the README.)