### PR TITLE
Document unix:// paths and add test for these

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ Usage
 
     @app.route('/')
     def index():
-        return redis_store.get('potato', 'Not Set')
+        return redis_store.get('potato') or 'Not Set'
 
 **Protip:** The `redis-py <https://github.com/andymccurdy/redis-py>`_ package currently holds the 'redis' namespace,
 so if you are looking to make use of it, your Redis object shouldn't be named 'redis'.

--- a/README.rst
+++ b/README.rst
@@ -45,13 +45,19 @@ Or if you *must* use easy_install:
 Configuration
 -------------
 
-Your configuration should be declared within your Flask config. You can declare
-via a Redis URL containing the database
+By default, Flask-Redis reads configuration from `REDIS_URL` key in Flask's
+`app.config`:
 
 .. code-block:: python
 
-    REDIS_URL = "redis://:password@localhost:6379/0"
+    REDIS_URL = "redis://[:password]@localhost:6379/0" # DEFAULT
+    REDIS_URL = "unix://[:password]@/path/to/socket.sock?db=0"
 
+
+Following two URL schemes are supported:
+
+- redis:// - creates a normal TCP socket connection
+- unix:// - creates a Unix Domain Socket connection
 
 To create the redis instance within your application
 

--- a/test_flask_redis.py
+++ b/test_flask_redis.py
@@ -44,6 +44,14 @@ def test_custom_prefix(app):
     assert redis_b.connection_pool.connection_kwargs['db'] == 2
 
 
+def test_unix_socket_urls(app):
+    '''Test whether Redis properly parses unix domain socket paths'''
+    app.config['REDIS_URL'] = 'unix:///var/run/redis/redis.sock?db=1'
+    r = FlaskRedis(app)
+    assert r.connection_pool.connection_kwargs['path'] == '/var/run/redis/redis.sock'
+    assert r.connection_pool.connection_kwargs['db'] == 1
+
+
 def test_strict_parameter(app):
     '''Test that initializing with the strict parameter set to True will use
     StrictRedis, and that False will keep using the old Redis class.'''


### PR DESCRIPTION
Add note about `unix:///` configuration support to README.

PS. `rediss://` is also parsed properly but I currently don't have setup for that.