### PR TITLE
remove default value from documentation as it's not supported

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ instance.
 
     @app.route('/')
     def index():
-        return redis_store.get('potato', 'Not Set')
+        return redis_store.get('potato')
 
 **Protip:** The redis-py_ package currently holds the 'redis' namespace, so if
 you are looking to make use of it, your Redis object shouldn't be named 'redis'.


### PR DESCRIPTION
As proposed by @underyx  in issue #33, I updated the documentation to reflect that there's no support yet for default values when getting stuff from redis.